### PR TITLE
Add Rails 5.0 support

### DIFF
--- a/active_waiter.gemspec
+++ b/active_waiter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.0"
 
-  s.add_dependency "rails", "~> 4.2.0"
+  s.add_dependency "rails", ">= 4.2", "< 5.1"
 
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-minitest"

--- a/app/views/active_waiter/jobs/_reload.html.erb
+++ b/app/views/active_waiter/jobs/_reload.html.erb
@@ -1,3 +1,3 @@
 <script>
-  setTimeout(function() { window.location.href = <%= url_for(params.merge(retries: @retries)).to_json.html_safe %>; }, 2000);
+  setTimeout(function() { window.location.href = <%= url_for(params.permit!.merge(retries: @retries)).to_json.html_safe %>; }, 2000);
 </script>

--- a/lib/active_waiter/version.rb
+++ b/lib/active_waiter/version.rb
@@ -1,3 +1,3 @@
 module ActiveWaiter
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
Changes:
- Do not call hash-specific method (e.g. #merge) directly on `params`
- Update gemspec to add Rails 5.0 support
- Bump patch version